### PR TITLE
入力元詳細と重複候補一覧の表示を見やすく調整

### DIFF
--- a/src/shinkoku/web/app.py
+++ b/src/shinkoku/web/app.py
@@ -1069,6 +1069,9 @@ def create_app(*, db_path: str, fiscal_year: int) -> FastAPI:
         preview = _preview_source_file(resolved) if exists and resolved else {"kind": "missing"}
         conn = get_connection(app.state.db_path)
         try:
+            account_names = {
+                r["code"]: r["name"] for r in conn.execute("SELECT code, name FROM accounts").fetchall()
+            }
             aliases = _source_file_aliases(path, base_dir=app.state.base_dir)
             if not aliases:
                 aliases = [path]
@@ -1082,18 +1085,43 @@ def create_app(*, db_path: str, fiscal_year: int) -> FastAPI:
                 "GROUP BY j.id ORDER BY j.date, j.id",
                 (app.state.fiscal_year, *aliases),
             ).fetchall()
-            items = [
-                {
-                    "id": r[0],
-                    "date": r[1],
-                    "description": r[2],
-                    "counterparty": r[3],
-                    "source": r[4],
-                    "source_file": r[5],
-                    "amount": r[6] or 0,
-                }
-                for r in rows
-            ]
+            journal_ids = [int(r[0]) for r in rows]
+            lines_by_journal: dict[int, list[dict[str, Any]]] = {}
+            if journal_ids:
+                line_placeholders = ", ".join("?" for _ in journal_ids)
+                line_rows = conn.execute(
+                    "SELECT journal_id, side, account_code, amount "
+                    "FROM journal_lines "
+                    f"WHERE journal_id IN ({line_placeholders}) "
+                    "ORDER BY id",
+                    tuple(journal_ids),
+                ).fetchall()
+                for lr in line_rows:
+                    jid = int(lr[0])
+                    lines_by_journal.setdefault(jid, []).append(
+                        {
+                            "side": lr[1],
+                            "account_code": lr[2],
+                            "amount": int(lr[3] or 0),
+                        }
+                    )
+
+            items = []
+            for r in rows:
+                jid = int(r[0])
+                journal_lines = lines_by_journal.get(jid, [])
+                items.append(
+                    {
+                        "id": jid,
+                        "date": r[1],
+                        "description": r[2],
+                        "counterparty": r[3],
+                        "source": r[4],
+                        "source_file": r[5],
+                        "amount": int(r[6] or 0),
+                        "lines": journal_lines,
+                    }
+                )
             monthly_rows = conn.execute(
                 "SELECT substr(j.date, 1, 7) AS ym, "
                 "SUM(CASE WHEN jl.side='debit' THEN jl.amount ELSE 0 END) AS debit_sum, "
@@ -1127,6 +1155,7 @@ def create_app(*, db_path: str, fiscal_year: int) -> FastAPI:
             size=resolved.stat().st_size if exists and resolved else None,
             preview=preview,
             items=items,
+            account_names=account_names,
             total_amount=sum(int(it["amount"]) for it in items),
             monthly_items=monthly_items,
         )

--- a/src/shinkoku/web/app.py
+++ b/src/shinkoku/web/app.py
@@ -630,19 +630,27 @@ def create_app(*, db_path: str, fiscal_year: int) -> FastAPI:
 
     # ========== Duplicate Candidates ==========
     @app.get("/duplicates", response_class=HTMLResponse)
-    def duplicates(request: Request, threshold: int = 70) -> str:
+    def duplicates(request: Request, threshold: int = 70, show_source: int | None = None) -> str:
+        if show_source is None and "show_source" not in request.query_params:
+            show_source = 1
+        show_source = 1 if show_source else 0
         res = ledger_check_duplicates(db_path=app.state.db_path, fiscal_year=app.state.fiscal_year, threshold=threshold)
         pairs: list[dict] = res.get("pairs", []) if isinstance(res, dict) else []
-        # Fetch minimal info for each journal in pairs
+        # Fetch journal metadata and lines for each candidate pair.
         ids: set[int] = set()
         for p in pairs:
             ids.add(int(p.get("journal_id_a")))
             ids.add(int(p.get("journal_id_b")))
         meta: dict[int, dict] = {}
+        account_names: dict[str, str] = {}
         if ids:
             conn = get_connection(app.state.db_path)
             try:
                 placeholders = ",".join(["?"] * len(ids))
+                account_names = {
+                    str(code): name
+                    for code, name in conn.execute("SELECT code, name FROM accounts").fetchall()
+                }
                 rows = conn.execute(
                     "SELECT j.id, j.date, COALESCE(j.description,''), j.counterparty, j.source, j.source_file, "
                     "SUM(CASE WHEN jl.side='debit' THEN jl.amount ELSE 0 END) AS debit_sum, "
@@ -661,7 +669,25 @@ def create_app(*, db_path: str, fiscal_year: int) -> FastAPI:
                         "source_file": r[5],
                         "debit": r[6] or 0,
                         "credit": r[7] or 0,
+                        "lines": [],
                     }
+                line_rows = conn.execute(
+                    "SELECT journal_id, side, account_code, amount "
+                    f"FROM journal_lines WHERE journal_id IN ({placeholders}) "
+                    "ORDER BY journal_id, id",
+                    list(ids),
+                ).fetchall()
+                for journal_id, side, account_code, amount in line_rows:
+                    journal = meta.get(int(journal_id))
+                    if journal is None:
+                        continue
+                    journal["lines"].append(
+                        {
+                            "side": side,
+                            "account_code": str(account_code),
+                            "amount": int(amount),
+                        }
+                    )
             finally:
                 conn.close()
         # Build view models
@@ -669,12 +695,19 @@ def create_app(*, db_path: str, fiscal_year: int) -> FastAPI:
         for p in pairs:
             a_id = int(p.get("journal_id_a"))
             b_id = int(p.get("journal_id_b"))
+            a_meta = meta.get(a_id, {"id": a_id, "lines": []})
+            b_meta = meta.get(b_id, {"id": b_id, "lines": []})
+            date = a_meta.get("date") or b_meta.get("date") or ""
+            amount = int(a_meta.get("debit") or b_meta.get("debit") or 0)
             items.append(
                 {
-                    "a": meta.get(a_id, {"id": a_id}),
-                    "b": meta.get(b_id, {"id": b_id}),
+                    "a": a_meta,
+                    "b": b_meta,
                     "score": p.get("score", 0),
                     "reason": p.get("reason", ""),
+                    "journals_url": _build_journals_url(
+                        query=f"from:{date} to:{date} mfrom:{amount} mto:{amount}",
+                    ) if date and amount else None,
                 }
             )
         template = env.get_template("duplicates.html")
@@ -682,9 +715,11 @@ def create_app(*, db_path: str, fiscal_year: int) -> FastAPI:
             request=request,
             fiscal_year=app.state.fiscal_year,
             threshold=threshold,
+            show_source=show_source,
             exact_count=res.get("exact_count", 0),
             suspected_count=res.get("suspected_count", 0),
             items=items,
+            account_names=account_names,
         )
 
     # ========== Description Summary ==========

--- a/src/shinkoku/web/templates/duplicates.html
+++ b/src/shinkoku/web/templates/duplicates.html
@@ -2,42 +2,103 @@
 {% block content %}
   <h3>重複候補一覧</h3>
   <form class="toolbar" method="get" action="/duplicates">
-    <label>しきい値: <input type="number" name="threshold" value="{{ threshold }}" min="0" max="100" step="5" /></label>
+    <label>しきい値:
+      <input type="number" name="threshold" value="{{ threshold }}" min="0" max="100" step="5" />
+    </label>
+    <label style="margin-left:12px">
+      <input type="checkbox" name="show_source" value="1" {% if show_source %}checked{% endif %} />
+      入力元を表示
+    </label>
     <button type="submit">更新</button>
   </form>
   <p class="muted">完全一致: {{ exact_count }} / 類似候補: {{ suspected_count }}</p>
-  <table>
-    <thead>
-      <tr>
-        <th colspan="5">候補A</th>
-        <th colspan="5">候補B</th>
-        <th>スコア</th>
-        <th>理由</th>
-      </tr>
-      <tr>
-        <th>ID</th><th>日付</th><th>摘要</th><th>相手先</th><th>金額(借/貸)</th>
-        <th>ID</th><th>日付</th><th>摘要</th><th>相手先</th><th>金額(借/貸)</th>
-        <th></th><th></th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for it in items %}
-      <tr>
-        <td>{{ it.a.id }}</td>
-        <td>{{ it.a.date or '' }}</td>
-        <td>{{ it.a.description or '' }}</td>
-        <td>{{ it.a.counterparty or '' }}</td>
-        <td style="text-align:right">{{ '{:,}'.format(it.a.debit | default(0)) }} / {{ '{:,}'.format(it.a.credit | default(0)) }}</td>
-        <td>{{ it.b.id }}</td>
-        <td>{{ it.b.date or '' }}</td>
-        <td>{{ it.b.description or '' }}</td>
-        <td>{{ it.b.counterparty or '' }}</td>
-        <td style="text-align:right">{{ '{:,}'.format(it.b.debit | default(0)) }} / {{ '{:,}'.format(it.b.credit | default(0)) }}</td>
-        <td style="text-align:right">{{ it.score }}</td>
-        <td>{{ it.reason }}</td>
-      </tr>
-      {% endfor %}
-    </tbody>
-  </table>
-{% endblock %}
 
+  {% for it in items %}
+    <div class="card" style="margin-bottom:16px">
+      <table>
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>日付</th>
+            <th>摘要</th>
+            <th>取引先</th>
+            {% if show_source %}
+            <th>入力元</th>
+            {% endif %}
+            <th colspan="2">借方</th>
+            <th colspan="2">貸方</th>
+          </tr>
+          <tr>
+            <th></th>
+            <th></th>
+            <th></th>
+            <th></th>
+            {% if show_source %}
+            <th></th>
+            {% endif %}
+            <th>勘定科目</th>
+            <th>金額</th>
+            <th>勘定科目</th>
+            <th>金額</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for journal in [it.a, it.b] %}
+            {% set debits = journal.lines | selectattr('side', 'equalto', 'debit') | list %}
+            {% set credits = journal.lines | selectattr('side', 'equalto', 'credit') | list %}
+            {% set row_count = [debits|length, credits|length, 1] | max %}
+            {% for i in range(0, row_count) %}
+            <tr>
+              {% if i == 0 %}
+                <td>{{ journal.id }}</td>
+                <td>
+                  {% if it.journals_url %}
+                    <a href="{{ it.journals_url }}">{{ journal.date or '' }}</a>
+                  {% else %}
+                    {{ journal.date or '' }}
+                  {% endif %}
+                </td>
+                <td>{{ journal.description or '' }}</td>
+                <td>{{ journal.counterparty or '未設定' }}</td>
+                {% if show_source %}
+                <td>{{ journal.source_file or '' }}</td>
+                {% endif %}
+              {% else %}
+                <td></td>
+                <td></td>
+                <td></td>
+                <td></td>
+                {% if show_source %}
+                <td></td>
+                {% endif %}
+              {% endif %}
+
+              {% if i < debits|length %}
+                <td>{{ debits[i].account_code }} {{ account_names.get(debits[i].account_code, '') }}</td>
+                <td style="text-align:right">{{ '{:,}'.format(debits[i].amount) }}</td>
+              {% else %}
+                <td></td>
+                <td></td>
+              {% endif %}
+
+              {% if i < credits|length %}
+                <td>{{ credits[i].account_code }} {{ account_names.get(credits[i].account_code, '') }}</td>
+                <td style="text-align:right">{{ '{:,}'.format(credits[i].amount) }}</td>
+              {% else %}
+                <td></td>
+                <td></td>
+              {% endif %}
+            </tr>
+            {% endfor %}
+          {% endfor %}
+          <tr>
+            <th>スコア</th>
+            <td style="text-align:right">{{ it.score }}</td>
+            <th>理由</th>
+            <td colspan="{% if show_source %}6{% else %}5{% endif %}">{{ it.reason }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  {% endfor %}
+{% endblock %}

--- a/src/shinkoku/web/templates/source_link_detail.html
+++ b/src/shinkoku/web/templates/source_link_detail.html
@@ -3,7 +3,7 @@
   <h3>入力元詳細</h3>
   <div class="grid">
     <div class="card">
-      <div class="muted">登録値</div>
+      <div class="muted">入力元</div>
       <div>{{ raw_path }}</div>
       <div class="muted" style="margin-top:8px">解決先</div>
       <div>{{ resolved_path or '未解決' }}</div>
@@ -28,7 +28,7 @@
     <div class="card">
       <div class="muted">プレビュー</div>
       {% if not exists %}
-        <p class="muted">ファイルは現在の Windows 環境から見つかりません。</p>
+        <p class="muted">ファイルは現在の Windows パスから見つかりません。</p>
       {% elif preview.kind == 'image' %}
         <img src="/source-links/raw?path={{ raw_path }}" alt="{{ raw_path }}" style="max-width:100%; height:auto; border:1px solid #ddd" />
       {% elif preview.kind == 'pdf' %}
@@ -48,13 +48,13 @@
       {% elif preview.kind == 'text' %}
         <pre style="white-space:pre-wrap; max-height:480px; overflow:auto">{{ preview.text }}</pre>
       {% else %}
-        <p class="muted">この形式は簡易プレビュー未対応です。必要なら「ブラウザで開く」を使ってください。</p>
+        <p class="muted">この形式のプレビューは未対応です。必要ならブラウザで開いて確認してください。</p>
       {% endif %}
     </div>
   </div>
 
   {% if monthly_items %}
-  <h4 style="margin-top:20px">月別小計</h4>
+  <h4 style="margin-top:20px">月別集計</h4>
   <table>
     <thead>
       <tr>
@@ -75,28 +75,62 @@
   </table>
   {% endif %}
 
-  <h4 style="margin-top:20px">関連仕訳</h4>
+  <h4 style="margin-top:20px">
+    <a href="/journals?query={{ ('file:' ~ '\"' ~ raw_path ~ '\"')|urlencode }}&show_source=1">関連仕訳</a>
+  </h4>
   <table>
     <thead>
       <tr>
-        <th>ID</th>
-        <th>日付</th>
-        <th>摘要</th>
-        <th>取引先</th>
-        <th>source</th>
+        <th rowspan="2">ID</th>
+        <th rowspan="2">日付</th>
+        <th rowspan="2">摘要</th>
+        <th rowspan="2">取引先</th>
+        <th colspan="2">借方</th>
+        <th colspan="2">貸方</th>
+      </tr>
+      <tr>
+        <th>勘定科目</th>
+        <th>金額</th>
+        <th>勘定科目</th>
         <th>金額</th>
       </tr>
     </thead>
     <tbody>
-      {% for it in items %}
-      <tr>
-        <td>{{ it.id }}</td>
-        <td>{{ it.date }}</td>
-        <td>{{ it.description or '' }}</td>
-        <td>{{ it.counterparty or '' }}</td>
-        <td class="muted">{{ it.source or '' }}</td>
-        <td style="text-align:right">{{ '{:,}'.format(it.amount) }}</td>
-      </tr>
+      {% for j in items %}
+        {% set debits = j.lines | selectattr('side', 'equalto', 'debit') | list %}
+        {% set credits = j.lines | selectattr('side', 'equalto', 'credit') | list %}
+        {% set n = [debits|length, credits|length] | max %}
+        {% for i in range(0, n) %}
+        <tr>
+          {% if i == 0 %}
+            <td>{{ j.id }}</td>
+            <td>{{ j.date }}</td>
+            <td>{{ j.description or '' }}</td>
+            <td>{{ j.counterparty or '未設定' }}</td>
+          {% else %}
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+          {% endif %}
+
+          {% if i < debits|length %}
+            <td>{{ debits[i].account_code }} {{ account_names.get(debits[i].account_code, '') }}</td>
+            <td style="text-align:right">{{ '{:,}'.format(debits[i].amount) }}</td>
+          {% else %}
+            <td></td>
+            <td></td>
+          {% endif %}
+
+          {% if i < credits|length %}
+            <td>{{ credits[i].account_code }} {{ account_names.get(credits[i].account_code, '') }}</td>
+            <td style="text-align:right">{{ '{:,}'.format(credits[i].amount) }}</td>
+          {% else %}
+            <td></td>
+            <td></td>
+          {% endif %}
+        </tr>
+        {% endfor %}
       {% endfor %}
     </tbody>
   </table>


### PR DESCRIPTION
## 概要

Web UI の小さめの参照画面調整です。

- 入力元詳細画面の関連仕訳を、仕訳一覧に近い見え方に整理
- 重複候補一覧を見やすく整理し、仕訳一覧への導線を追加

どちらも参照・確認のしやすさ改善が目的です。

## 変更内容

### 入力元詳細
- `関連仕訳` の表示を仕訳一覧寄りに変更
- 列構成を
  - ID
  - 日付
  - 摘要
  - 取引先
  - 借方科目 / 借方金額
  - 貸方科目 / 貸方金額
  に整理
- 入力元は上部に出ているため、関連仕訳テーブルからは除外
- 行内リンクは付けず、見た目を優先
- `関連仕訳` 見出し自体を、入力元で絞り込んだ `仕訳一覧` へのリンクに変更

### 重複候補一覧
- 候補A / 候補B を左右比較する旧形式から、1セットごとに見やすい表示へ変更
- 各候補を仕訳一覧に近い列構成で表示
  - ID
  - 日付
  - 摘要
  - 取引先
  - 借方科目 / 借方金額
  - 貸方科目 / 貸方金額
- 候補2件の下に `スコア / 理由` を1行で表示
- `候補A / 候補B` の見分け列は削除
- `入力元を表示` チェックボックスを追加し、初期表示は ON
- 日付は `日付 + 金額` 条件付きの `仕訳一覧` へのリンクに変更

## 背景
- 入力元詳細では、金額だけでは借方/貸方の見え方が分かりづらかった
- 重複候補一覧では、仕訳一覧と表示形式が異なり、内容比較や深掘りがしづらかった
- 重複判定ロジックが `日付 + 借方合計` をベースにしているため、そこから `仕訳一覧` へ飛べる導線があると確認しやすい

## 確認
- `/source-links/detail` で関連仕訳の表示確認
- `関連仕訳` 見出しから、入力元で絞った `仕訳一覧` に遷移することを確認
- `/duplicates` で候補表示の確認
- `入力元を表示` の ON/OFF で列表示が切り替わることを確認
- 重複候補の日付リンクから `仕訳一覧` へ遷移できることを確認

## 補足
- 重複候補の消込や ignore 状態の保持は今回含めていません
- その検討用メモは issue #7 に分離しています
