### PR TITLE
貸借対照表に当期損益の表示を追加

### DIFF
--- a/src/shinkoku/web/templates/bs.html
+++ b/src/shinkoku/web/templates/bs.html
@@ -40,6 +40,17 @@
               <td style="text-align:right">{{ '{:,}'.format(e.amount) }}</td>
             </tr>
             {% endfor %}
+            {% if bs.net_income > 0 %}
+            <tr>
+              <td>当期純利益</td>
+              <td style="text-align:right">{{ '{:,}'.format(bs.net_income) }}</td>
+            </tr>
+            {% elif bs.net_income < 0 %}
+            <tr>
+              <td>当期純損失</td>
+              <td style="text-align:right">-{{ '{:,}'.format(0 - bs.net_income) }}</td>
+            </tr>
+            {% endif %}
           </tbody>
           <tfoot>
             <tr>


### PR DESCRIPTION
## 概要

貸借対照表で、決算振替前でも資産と負債・純資産の見え方が分かりやすくなるように、純資産部へ当期損益を表示するようにしました。

## 変更内容

- 貸借対照表の純資産部に `当期純利益` / `当期純損失` を追加
- 黒字の場合
  - 貸方側に `当期純利益` を表示
- 赤字の場合
  - 貸方マイナスで `当期純損失` を表示

## 背景

現状の BS ロジックでは `total_equity` に当期損益を含めている一方、明細表示にはその行が出ていませんでした。

そのため、
- 合計は合っている
- ただし明細の見た目だけが不足している

という状態になっていました。

## 確認

- `/bs` で `当期純利益` が表示されることを確認
- 今回のサンプルデータでは黒字のため `当期純利益` が表示されることを確認
- 赤字時は `当期純損失` を貸方マイナス表示する想定

## 補足

- 今回は表示調整のみ
- 決算仕訳や締め処理そのものは追加していません
