### PR TITLE
Web UI のデモ・スモークテストを追加し、依存関係を整理

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.2.1] - 2026-04-20
+
+### Added
+- 参照中心の Web UI 導線を追加・整理（仕訳一覧、各種サマリ、入力元サマリ、入力元詳細、月次グラフなど）
+- `web-ui` スキルを追加
+- `AGENTS.md` を追加し、Codex向けの参照導線を整備
+- `import_data` でカード明細、銀行口座明細、ERPNext CSV の追加フォーマット対応を追加
+- `input_samples/` に架空のサンプルデータセットを追加
+
+### Changed
+- Web UI は更新系を持たず、参照と確認を中心にする方針へ整理
+- 仕訳一覧の絞り込みを検索式ベースに拡張
+- 月次サマリから仕訳一覧へのドリルダウン導線を追加
+- 貸借対照表で当期純利益 / 当期純損失を純資産部に表示するよう変更
+- `setup` スキルと README を clone + `uv sync` 前提の開発者向けフローに調整
+- `.gitignore` とテンプレート管理を見直し、Web UI テンプレートを通常の Git 管理対象に変更
+
 ## [0.2.0] - 2026-02-24
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,6 +252,15 @@ uv run shinkoku profile --config shinkoku.config.yaml
 | `src/shinkoku/cli/furusato.py` | 4 | ふるさと納税 CLI（add, list, delete, summary） |
 | `src/shinkoku/cli/profile.py` | — | プロファイル取得 CLI（直接コマンド） |
 
+### Web UI
+
+| ファイルパス | 役割 |
+|------------|------|
+| `src/shinkoku/cli/web.py` | `shinkoku web` の CLI エントリポイント。引数解釈と Web アプリ起動。 |
+| `src/shinkoku/web/app.py` | FastAPI ルーティング、画面用データ生成、検索式の解釈、CSV ダウンロード、ヘルスチェック。 |
+
+- 起動: `uv run shinkoku web --db-path shinkoku.db --fiscal-year 2025 --port 8010`
+
 ### スキル（skills/）
 
 | ファイルパス | 役割 |

--- a/input_samples/README.md
+++ b/input_samples/README.md
@@ -21,6 +21,8 @@
   - 楽天カード CSV サンプル
 - `aeon_card/`
   - イオンカード CSV サンプル
+- `fixed_assets/`
+  - 固定資産台帳用 CSV サンプル
 
 ## 方針
 
@@ -31,3 +33,4 @@
 
 - `input_samples` 配下の CSV をそのまま importer にかけて動作確認できます
 - 画面確認や検索条件の確認、重複候補の表示確認などに使う想定です
+- `fixed_assets/fixed_assets.csv` は現状の通常 importer ではなく、画面確認用の demo DB 構築スクリプトから読み込む想定です

--- a/input_samples/fixed_assets/fixed_assets.csv
+++ b/input_samples/fixed_assets/fixed_assets.csv
@@ -1,0 +1,2 @@
+name,acquisition_date,acquisition_cost,useful_life,method,business_use_ratio,accumulated_depreciation,memo
+開発用ノートPC,2025-02-01,198000,4,straight_line,100,0,画面確認用サンプル

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,8 +51,14 @@ dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
     "pytest-cov>=5.0",
+    "httpx>=0.27",
     "ruff>=0.4",
     "mypy>=1.10",
+    "fpdf2>=2.7",
+    "lxml>=6.0.2",
+    "playwright>=1.58.0",
+    "pre-commit>=4.0.0",
+    "types-pyyaml>=6.0.12.20250915",
 ]
 
 [project.scripts]
@@ -76,12 +82,3 @@ markers = [
 [tool.ruff]
 line-length = 100
 target-version = "py311"
-
-[dependency-groups]
-dev = [
-    "fpdf2>=2.7",
-    "lxml>=6.0.2",
-    "playwright>=1.58.0",
-    "pre-commit>=4.0.0",
-    "types-pyyaml>=6.0.12.20250915",
-]

--- a/src/shinkoku/cli/web.py
+++ b/src/shinkoku/cli/web.py
@@ -27,7 +27,7 @@ def _run(args: argparse.Namespace) -> None:
     try:
         from shinkoku.web.app import create_app
         import uvicorn
-    except Exception as e:
+    except Exception:
         print(
             (
                 "{\"status\": \"error\", \"message\": "

--- a/src/shinkoku/duplicate_detection.py
+++ b/src/shinkoku/duplicate_detection.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sqlite3
 from collections import defaultdict
+from typing import TypedDict
 
 from shinkoku.hashing import compute_journal_hash
 from shinkoku.models import (
@@ -12,6 +13,14 @@ from shinkoku.models import (
     DuplicateWarning,
     JournalEntry,
 )
+
+
+class _JournalAggregate(TypedDict):
+    id: int
+    date: str
+    description: str | None
+    account_codes: list[str]
+    debit_total: int
 
 
 def check_duplicate_on_insert(
@@ -145,49 +154,41 @@ def find_duplicate_pairs(
     ).fetchall()
 
     journals: list[tuple[int, str, str | None, str, int]] = []
-    by_journal: dict[int, dict[str, object]] = {}
+    by_journal: dict[int, _JournalAggregate] = {}
     for row in journal_lines:
         journal_id = int(row[0])
         item = by_journal.get(journal_id)
         if item is None:
             item = {
                 "id": journal_id,
-                "date": row[1],
-                "description": row[2],
+                "date": str(row[1]),
+                "description": str(row[2]) if row[2] is not None else None,
                 "account_codes": [],
                 "debit_total": 0,
             }
             by_journal[journal_id] = item
 
-        account_codes = item["account_codes"]
-        assert isinstance(account_codes, list)
-        account_codes.append(str(row[3]))
+        item["account_codes"].append(str(row[3]))
 
         if row[4] == "debit":
-            debit_total = item["debit_total"]
-            assert isinstance(debit_total, int)
-            item["debit_total"] = debit_total + int(row[5])
+            item["debit_total"] = item["debit_total"] + int(row[5])
 
     for item in by_journal.values():
-        account_codes = item["account_codes"]
-        assert isinstance(account_codes, list)
-        debit_total = item["debit_total"]
-        assert isinstance(debit_total, int)
         journals.append(
             (
-                int(item["id"]),
-                str(item["date"]),
+                item["id"],
+                item["date"],
                 item["description"],
-                ",".join(account_codes),
-                debit_total,
+                ",".join(item["account_codes"]),
+                item["debit_total"],
             )
         )
 
     # Index by (date, debit_total) for O(n) grouping
     groups: dict[tuple[str, int], list[tuple[int, str | None, str | None]]] = defaultdict(list)
-    for j in journals:
-        key = (j[1], j[4])  # (date, debit_total)
-        groups[key].append((j[0], j[2], j[3]))  # (id, description, account_codes)
+    for journal_row in journals:
+        key = (journal_row[1], journal_row[4])  # (date, debit_total)
+        groups[key].append((journal_row[0], journal_row[2], journal_row[3]))  # (id, description, account_codes)
 
     # Already-seen pairs from exact matches
     seen = {(p.journal_id_a, p.journal_id_b) for p in pairs}

--- a/src/shinkoku/web/app.py
+++ b/src/shinkoku/web/app.py
@@ -1473,7 +1473,9 @@ def create_app(*, db_path: str, fiscal_year: int) -> FastAPI:
     # Import
     @app.get("/import", response_class=HTMLResponse)
     def import_index(request: Request) -> str:
-        return PlainTextResponse("import UI is disabled", status_code=410)
+        return RedirectResponse(url="/journals", status_code=307)
+        template = env.get_template("import_upload.html")
+        return template.render(request=request, fiscal_year=app.state.fiscal_year)
 
     @app.post("/import/upload", response_class=HTMLResponse)
     async def import_upload(request: Request, files: list[UploadFile] = File(...)) -> str:

--- a/src/shinkoku/web/app.py
+++ b/src/shinkoku/web/app.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
 from pathlib import Path
+from collections.abc import Callable
 from typing import Any
 import shlex
 import calendar
 
 from fastapi import FastAPI, Request
-from fastapi.responses import HTMLResponse, RedirectResponse, FileResponse
+from fastapi.responses import HTMLResponse, RedirectResponse, FileResponse, Response
 from fastapi.staticfiles import StaticFiles
+from starlette.routing import Route
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 from shinkoku.models import JournalSearchParams, JournalEntry
@@ -36,7 +38,7 @@ import re
 from urllib.parse import urlencode
 
 try:
-    import requests
+    import requests  # type: ignore[import-untyped]
 except Exception:  # pragma: no cover
     requests = None  # type: ignore
 
@@ -140,6 +142,39 @@ def _preview_source_file(path: Path) -> dict[str, Any]:
             return {"kind": "csv", "rows": rows}
         return {"kind": "text", "text": text[:4000]}
     return {"kind": "binary"}
+
+
+def _trial_balance_sort_count(account: dict[str, Any]) -> int:
+    return (
+        1
+        if int(account.get("debit_total", 0) or 0) != 0
+        or int(account.get("credit_total", 0) or 0) != 0
+        else 0
+    )
+
+
+def _trial_balance_sort_name(account: dict[str, Any]) -> str:
+    return str(account.get("account_name", ""))
+
+
+def _trial_balance_sort_code(account: dict[str, Any]) -> str:
+    return str(account.get("account_code", ""))
+
+
+def _trial_balance_sort_amount(account: dict[str, Any]) -> int:
+    return abs(int(account.get("balance", 0) or 0))
+
+
+def _journal_sort_id(journal: dict[str, Any]) -> object:
+    return journal.get("id", 0)
+
+
+def _journal_sort_date(journal: dict[str, Any]) -> object:
+    return journal.get("date", "")
+
+
+def _journal_sort_source_file(journal: dict[str, Any]) -> object:
+    return journal.get("source_file") or ""
 
 
 def _build_journals_url(**params: Any) -> str:
@@ -368,18 +403,17 @@ def create_app(*, db_path: str, fiscal_year: int) -> FastAPI:
         order = order or "amount"
         dir = dir or "desc"
         reverse = dir != "asc"
+        sort_key: Callable[[dict[str, Any]], Any]
         if order == "count":
-            sort_key = lambda a: (
-                1 if int(a.get("debit_total", 0) or 0) != 0 or int(a.get("credit_total", 0) or 0) != 0 else 0
-            )
+            sort_key = _trial_balance_sort_count
         elif order == "name":
-            sort_key = lambda a: str(a.get("account_name", ""))
+            sort_key = _trial_balance_sort_name
             reverse = dir == "desc"
         elif order == "code":
-            sort_key = lambda a: str(a.get("account_code", ""))
+            sort_key = _trial_balance_sort_code
             reverse = dir == "desc"
         else:
-            sort_key = lambda a: abs(int(a.get("balance", 0) or 0))
+            sort_key = _trial_balance_sort_amount
         accounts = sorted(accounts, key=sort_key, reverse=reverse)
 
         tb_view = dict(tb) if isinstance(tb, dict) else {"accounts": []}
@@ -435,7 +469,7 @@ def create_app(*, db_path: str, fiscal_year: int) -> FastAPI:
         show_source: int = 0,
         sort: str | None = None,
         dir: str | None = None,
-    ) -> str:
+    ) -> Any:
         try:
             counterparty = _blank_to_none(counterparty)
             source_file = _blank_to_none(source_file)
@@ -498,15 +532,15 @@ def create_app(*, db_path: str, fiscal_year: int) -> FastAPI:
             else:
                 journals_all = None
 
-            sort_key = None
+            sort_key: Callable[[dict[str, Any]], Any] | None = None
             if effective_sort in {"id", "date", "source_file"}:
                 if effective_sort == "id":
-                    sort_key = lambda j: j.get("id", 0)
+                    sort_key = _journal_sort_id
                 elif effective_sort == "date":
-                    sort_key = lambda j: j.get("date", "")
+                    sort_key = _journal_sort_date
                 elif effective_sort == "source_file":
-                    sort_key = lambda j: (j.get("source_file") or "")
-            if sort_key and isinstance(result, dict) and isinstance(result.get("journals"), list):
+                    sort_key = _journal_sort_source_file
+            if sort_key is not None and isinstance(result, dict) and isinstance(result.get("journals"), list):
                 result["journals"] = sorted(
                     result["journals"],
                     key=sort_key,
@@ -611,7 +645,7 @@ def create_app(*, db_path: str, fiscal_year: int) -> FastAPI:
 
     @app.get("/debug/routes")
     def debug_routes() -> list[str]:
-        return [r.path for r in app.router.routes]
+        return [route.path for route in app.router.routes if isinstance(route, Route)]
 
     @app.get("/gl/{account_code}", response_class=HTMLResponse)
     def general_ledger(request: Request, account_code: str) -> str:
@@ -639,8 +673,8 @@ def create_app(*, db_path: str, fiscal_year: int) -> FastAPI:
         # Fetch journal metadata and lines for each candidate pair.
         ids: set[int] = set()
         for p in pairs:
-            ids.add(int(p.get("journal_id_a")))
-            ids.add(int(p.get("journal_id_b")))
+            ids.add(int(p.get("journal_id_a") or 0))
+            ids.add(int(p.get("journal_id_b") or 0))
         meta: dict[int, dict] = {}
         account_names: dict[str, str] = {}
         if ids:
@@ -693,8 +727,8 @@ def create_app(*, db_path: str, fiscal_year: int) -> FastAPI:
         # Build view models
         items: list[dict] = []
         for p in pairs:
-            a_id = int(p.get("journal_id_a"))
-            b_id = int(p.get("journal_id_b"))
+            a_id = int(p.get("journal_id_a") or 0)
+            b_id = int(p.get("journal_id_b") or 0)
             a_meta = meta.get(a_id, {"id": a_id, "lines": []})
             b_meta = meta.get(b_id, {"id": b_id, "lines": []})
             date = a_meta.get("date") or b_meta.get("date") or ""
@@ -818,7 +852,7 @@ def create_app(*, db_path: str, fiscal_year: int) -> FastAPI:
         date_to: str | None = None,
         limit: int = 100,
         offset: int = 0,
-    ) -> str:
+    ) -> RedirectResponse:
         return RedirectResponse(
             url=_build_journals_url(
                 query=f'desc:"{desc}"',
@@ -1015,7 +1049,7 @@ def create_app(*, db_path: str, fiscal_year: int) -> FastAPI:
         return template.render(request=request, fiscal_year=app.state.fiscal_year, accounts=accounts)
 
     @app.get("/cashbook/{account_code}", response_class=HTMLResponse)
-    def cashbook_view(request: Request, account_code: str) -> str:
+    def cashbook_view(request: Request, account_code: str) -> RedirectResponse:
         return RedirectResponse(url=f"/gl/{account_code}", status_code=307)
         gl = ledger_general_ledger(
             db_path=app.state.db_path,
@@ -1065,8 +1099,8 @@ def create_app(*, db_path: str, fiscal_year: int) -> FastAPI:
                     "exists": exists,
                     "resolved_path": str(resolved) if resolved else "",
                     "display_path": _safe_relpath(resolved, base_dir=app.state.base_dir) if resolved else (raw_path or ""),
-                    "size": resolved.stat().st_size if exists else None,
-                    "file_uri": resolved.as_uri() if exists else "",
+                    "size": resolved.stat().st_size if exists and resolved is not None else None,
+                    "file_uri": resolved.as_uri() if exists and resolved is not None else "",
                 }
                 if q:
                     ql = q.lower()
@@ -1286,7 +1320,7 @@ def create_app(*, db_path: str, fiscal_year: int) -> FastAPI:
         date_to: str | None = None,
         limit: int = 100,
         offset: int = 0,
-    ) -> str:
+    ) -> RedirectResponse:
         return RedirectResponse(
             url=_build_journals_url(
                 query=f'cp:"{name}"',
@@ -1472,11 +1506,11 @@ def create_app(*, db_path: str, fiscal_year: int) -> FastAPI:
 
     # Import
     @app.get("/import", response_class=HTMLResponse)
-    def import_index(request: Request) -> str:
+    def import_index(request: Request) -> PlainTextResponse:
         return PlainTextResponse("import UI is disabled", status_code=410)
 
     @app.post("/import/upload", response_class=HTMLResponse)
-    async def import_upload(request: Request, files: list[UploadFile] = File(...)) -> str:
+    async def import_upload(request: Request, files: list[UploadFile] = File(...)) -> PlainTextResponse:
         return PlainTextResponse("import UI is disabled", status_code=410)
         uploads = Path(__file__).parent / "../../../../shinkoku/shinkoku/work/uploads"
         uploads = uploads.resolve()
@@ -1510,7 +1544,7 @@ def create_app(*, db_path: str, fiscal_year: int) -> FastAPI:
         saved_paths: list[str] = Form(...),
         credit_code: str = Form("2030"),
         source: str = Form("csv_import"),
-    ) -> str:
+    ) -> PlainTextResponse:
         return PlainTextResponse("import UI is disabled", status_code=410)
         names = _account_names_map(app.state.db_path)
         multi_results: list[dict] = []
@@ -1554,7 +1588,7 @@ def create_app(*, db_path: str, fiscal_year: int) -> FastAPI:
         saved_paths: list[str] = Form(...),
         credit_code: str = Form("2030"),
         source: str = Form("csv_import"),
-    ) -> str:
+    ) -> PlainTextResponse:
         return PlainTextResponse("import UI is disabled", status_code=410)
         entries: list[dict[str, Any]] = []
         for sp in saved_paths:
@@ -1601,7 +1635,7 @@ def create_app(*, db_path: str, fiscal_year: int) -> FastAPI:
         return template.render(request=request, fiscal_year=app.state.fiscal_year, audit=res)
 
     @app.get("/audit/detail", response_class=HTMLResponse)
-    def audit_detail(request: Request, log_id: int) -> str:
+    def audit_detail(request: Request, log_id: int) -> Any:
         conn = get_connection(app.state.db_path)
         try:
             row = conn.execute(
@@ -1660,12 +1694,12 @@ def create_app(*, db_path: str, fiscal_year: int) -> FastAPI:
 
     # Path parameter variant for convenience
     @app.get("/audit/detail/{log_id}", response_class=HTMLResponse)
-    def audit_detail_path(request: Request, log_id: int) -> str:
+    def audit_detail_path(request: Request, log_id: int) -> Any:
         return audit_detail(request, log_id)
 
     # Diff view for audit log (before/after highlighting)
     @app.get("/audit/diff", response_class=HTMLResponse)
-    def audit_diff(request: Request, log_id: int) -> str:
+    def audit_diff(request: Request, log_id: int) -> Any:
         conn = get_connection(app.state.db_path)
         try:
             row = conn.execute(
@@ -1714,12 +1748,12 @@ def create_app(*, db_path: str, fiscal_year: int) -> FastAPI:
         )
 
     @app.get("/audit/diff/{log_id}", response_class=HTMLResponse)
-    def audit_diff_path(request: Request, log_id: int) -> str:
+    def audit_diff_path(request: Request, log_id: int) -> Any:
         return audit_diff(request, log_id)
 
     # ===== AI Reading (Receipt OCR via LM Studio Vision) =====
     @app.get("/ai/reading-receipt", response_class=HTMLResponse)
-    def ai_reading_receipt_index(request: Request) -> str:
+    def ai_reading_receipt_index(request: Request) -> RedirectResponse:
         return RedirectResponse(url="/journals", status_code=307)
         template = env.get_template("ai_reading_upload.html")
         cfg = _llm_config()
@@ -1735,7 +1769,7 @@ def create_app(*, db_path: str, fiscal_year: int) -> FastAPI:
         request: Request,
         files: list[UploadFile] = File(...),
         note: str | None = None,
-    ) -> str:
+    ) -> Any:
         return PlainTextResponse("AI reading UI is disabled", status_code=410)
         # Save files under work/uploads
         uploads = Path(__file__).parent / "../../../../shinkoku/shinkoku/work/uploads"
@@ -1804,7 +1838,7 @@ def create_app(*, db_path: str, fiscal_year: int) -> FastAPI:
         debit_code: list[str] = Form(...),
         credit_code: list[str] = Form(...),
         amount: list[int] = Form(...),
-    ) -> str:
+    ) -> PlainTextResponse:
         return PlainTextResponse("AI reading UI is disabled", status_code=410)
         entries: list[JournalEntry] = []
         n = len(saved_path)

--- a/src/shinkoku/web/app.py
+++ b/src/shinkoku/web/app.py
@@ -1473,9 +1473,7 @@ def create_app(*, db_path: str, fiscal_year: int) -> FastAPI:
     # Import
     @app.get("/import", response_class=HTMLResponse)
     def import_index(request: Request) -> str:
-        return RedirectResponse(url="/journals", status_code=307)
-        template = env.get_template("import_upload.html")
-        return template.render(request=request, fiscal_year=app.state.fiscal_year)
+        return PlainTextResponse("import UI is disabled", status_code=410)
 
     @app.post("/import/upload", response_class=HTMLResponse)
     async def import_upload(request: Request, files: list[UploadFile] = File(...)) -> str:

--- a/src/shinkoku/web/templates/journals.html
+++ b/src/shinkoku/web/templates/journals.html
@@ -3,6 +3,8 @@
   <div class="toolbar" style="display:flex; align-items:center; justify-content:space-between; gap:12px; margin-top:4px;">
     <h3 style="margin:0;">仕訳一覧</h3>
     <div class="muted" style="white-space:nowrap;">
+      <a href="/import">CSVインポート</a>
+      &nbsp;|&nbsp;
       <a href="/journals.csv?query={{ query|urlencode }}&q={{ q|urlencode }}&source={{ source|urlencode }}&date_from={{ date_from }}&date_to={{ date_to }}&account_code={{ account_code|urlencode }}&counterparty={{ counterparty|urlencode }}&source_file={{ source_file|urlencode }}&amount_min={{ amount_min }}&amount_max={{ amount_max }}&limit={{ limit }}">CSVダウンロード</a>
     </div>
   </div>

--- a/src/shinkoku/web/templates/journals.html
+++ b/src/shinkoku/web/templates/journals.html
@@ -3,8 +3,6 @@
   <div class="toolbar" style="display:flex; align-items:center; justify-content:space-between; gap:12px; margin-top:4px;">
     <h3 style="margin:0;">仕訳一覧</h3>
     <div class="muted" style="white-space:nowrap;">
-      <a href="/import">CSVインポート</a>
-      &nbsp;|&nbsp;
       <a href="/journals.csv?query={{ query|urlencode }}&q={{ q|urlencode }}&source={{ source|urlencode }}&date_from={{ date_from }}&date_to={{ date_to }}&account_code={{ account_code|urlencode }}&counterparty={{ counterparty|urlencode }}&source_file={{ source_file|urlencode }}&amount_min={{ amount_min }}&amount_max={{ amount_max }}&limit={{ limit }}">CSVダウンロード</a>
     </div>
   </div>

--- a/tests/helpers/demo_data.py
+++ b/tests/helpers/demo_data.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+from shinkoku.db import init_db
+from shinkoku.master_accounts import MASTER_ACCOUNTS
+from shinkoku.models import JournalEntry, JournalLine, OpeningBalanceInput
+from shinkoku.tools.import_data import import_csv, import_record_source
+from shinkoku.tools.ledger import (
+    ledger_add_journal,
+    ledger_set_opening_balances_batch,
+    ledger_update_journal,
+)
+
+
+def _load_master_accounts(db_path: str, fiscal_year: int) -> None:
+    conn = init_db(db_path)
+    try:
+        for account in MASTER_ACCOUNTS:
+            conn.execute(
+                "INSERT OR IGNORE INTO accounts (code, name, category, sub_category, tax_category) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (
+                    account["code"],
+                    account["name"],
+                    account["category"],
+                    account["sub_category"],
+                    account["tax_category"],
+                ),
+            )
+        conn.execute("INSERT OR IGNORE INTO fiscal_years (year) VALUES (?)", (fiscal_year,))
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _map_expense_hint(account_hint: str | None, description: str) -> str:
+    hint = (account_hint or "").strip()
+    if hint == "外注費":
+        return "5300"
+    if hint == "仕入高":
+        return "5001"
+    desc = description.upper()
+    if any(token in desc for token in ["OPENAI", "ANTHROPIC", "MIDJOURNEY", "ADOBE", "ENVATO"]):
+        return "5140"
+    if any(token in description for token in ["電車", "バス", "タクシー", "JR", "SUICA", "PASMO"]):
+        return "5130"
+    if any(token in description for token in ["素材", "備品", "文具", "ノート", "ストア"]):
+        return "5190"
+    return "5270"
+
+
+def _map_deposit_credit_code(description: str, source_file: str) -> str:
+    source_name = Path(source_file).name.lower()
+    if source_name.endswith(".csv") and any(token in source_file for token in ["mufg_bank", "smbc_bank"]):
+        if "振込入金" in description:
+            return "1010"
+        if "利息" in description:
+            return "4100"
+        if any(token in description for token in ["資金移動", "ｼｷﾝｲﾄﾞｳ", "口座移動"]):
+            return "1001"
+        return "4110"
+    return "4001"
+
+
+def _candidate_to_entry(candidate: dict, source_file: str) -> JournalEntry | None:
+    amount = int(candidate.get("amount") or 0)
+    if amount <= 0:
+        return None
+
+    date = str(candidate.get("date") or "")
+    description = str(candidate.get("description") or "")
+    counterparty = candidate.get("counterparty")
+    direction = candidate.get("direction")
+
+    debit_code: str
+    credit_code: str
+    if direction == "deposit":
+        debit_code, credit_code = "1002", _map_deposit_credit_code(description, source_file)
+    elif direction == "withdrawal":
+        debit_code, credit_code = _map_expense_hint(candidate.get("account_hint"), description), "1002"
+    elif direction == "sales":
+        debit_code, credit_code = "1010", "4001"
+    elif direction == "purchase":
+        debit_code, credit_code = _map_expense_hint(candidate.get("account_hint"), description), "2030"
+    elif direction == "receipt":
+        debit_code, credit_code = "1002", "1010"
+    elif direction == "payment":
+        debit_code, credit_code = "2030", "1002"
+    elif direction == "debit":
+        debit_code, credit_code = _map_expense_hint(candidate.get("account_hint"), description), "1002"
+    elif direction == "credit":
+        debit_code, credit_code = "1002", "4001"
+    else:
+        debit_code, credit_code = _map_expense_hint(candidate.get("account_hint"), description), "2030"
+
+    return JournalEntry(
+        date=date,
+        description=description,
+        counterparty=str(counterparty) if counterparty else None,
+        lines=[
+            JournalLine(side="debit", account_code=debit_code, amount=amount),
+            JournalLine(side="credit", account_code=credit_code, amount=amount),
+        ],
+        source="csv_import",
+        source_file=source_file,
+    )
+
+
+def _load_csv_candidates(db_path: str, fiscal_year: int, sample_file: Path) -> None:
+    res = import_csv(file_path=str(sample_file))
+    if res.get("status") != "ok":
+        return
+
+    added_count = 0
+    for candidate in res.get("candidates", []):
+        entry = _candidate_to_entry(candidate, str(sample_file))
+        if entry is None:
+            continue
+        result = ledger_add_journal(db_path=db_path, fiscal_year=fiscal_year, entry=entry, force=True)
+        if result.get("status") == "ok":
+            added_count += 1
+
+    import_record_source(
+        db_path=db_path,
+        fiscal_year=fiscal_year,
+        file_path=str(sample_file),
+        row_count=added_count,
+    )
+
+
+def _load_fixed_assets_sample(db_path: str, fiscal_year: int, sample_file: Path) -> None:
+    conn = init_db(db_path)
+    try:
+        with sample_file.open("r", encoding="utf-8") as f:
+            for row in csv.DictReader(f):
+                conn.execute(
+                    "INSERT INTO fixed_assets "
+                    "(name, acquisition_date, acquisition_cost, useful_life, method, "
+                    "business_use_ratio, accumulated_depreciation, fiscal_year, memo) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        row["name"],
+                        row["acquisition_date"],
+                        int(row["acquisition_cost"]),
+                        int(row["useful_life"]),
+                        row["method"],
+                        int(row["business_use_ratio"]),
+                        int(row["accumulated_depreciation"]),
+                        fiscal_year,
+                        row.get("memo", ""),
+                    ),
+                )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _seed_opening_balances(db_path: str, fiscal_year: int) -> None:
+    ledger_set_opening_balances_batch(
+        db_path=db_path,
+        fiscal_year=fiscal_year,
+        balances=[
+            OpeningBalanceInput(account_code="1002", amount=500000),
+            OpeningBalanceInput(account_code="3001", amount=500000),
+        ],
+    )
+
+
+def _seed_audit_and_duplicates(db_path: str, fiscal_year: int, samples_dir: Path) -> None:
+    target_file = samples_dir / "erpnext" / "sales_invoices.csv"
+    conn = init_db(db_path)
+    try:
+        row = conn.execute(
+            "SELECT j.id, j.date, COALESCE(j.description,''), COALESCE(j.counterparty,''), "
+            "j.source, COALESCE(j.source_file,''), jl.side, jl.account_code, jl.amount "
+            "FROM journals j "
+            "INNER JOIN journal_lines jl ON jl.journal_id = j.id "
+            "WHERE j.fiscal_year = ? AND j.source_file = ? "
+            "ORDER BY j.id, jl.id",
+            (fiscal_year, str(target_file)),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    if row:
+        journal_id = int(row[0][0])
+        lines = [
+            JournalLine(side=str(item[6]), account_code=str(item[7]), amount=int(item[8]))
+            for item in row
+            if int(item[0]) == journal_id
+        ]
+        updated = JournalEntry(
+            date=str(row[0][1]),
+            description=str(row[0][2]),
+            counterparty="株式会社青葉工務店",
+            lines=lines,
+            source=str(row[0][4] or "csv_import"),
+            source_file=str(row[0][5]) or None,
+        )
+        ledger_update_journal(
+            db_path=db_path,
+            journal_id=journal_id,
+            fiscal_year=fiscal_year,
+            entry=updated,
+        )
+
+    dup_a = JournalEntry(
+        date="2025-03-27",
+        description="重複候補サンプルA",
+        lines=[
+            JournalLine(side="debit", account_code="5190", amount=50000),
+            JournalLine(side="credit", account_code="1002", amount=50000),
+        ],
+        source="manual",
+    )
+    dup_b = JournalEntry(
+        date="2025-03-27",
+        description="重複候補サンプルB",
+        lines=[
+            JournalLine(side="debit", account_code="5270", amount=50000),
+            JournalLine(side="credit", account_code="1001", amount=50000),
+        ],
+        source="manual",
+    )
+    ledger_add_journal(db_path=db_path, fiscal_year=fiscal_year, entry=dup_a, force=True)
+    ledger_add_journal(db_path=db_path, fiscal_year=fiscal_year, entry=dup_b, force=True)
+
+
+def build_capture_demo_db(
+    *,
+    db_path: str,
+    fiscal_year: int,
+    samples_dir: str,
+    reference_export_path: str | None = None,
+) -> dict[str, int | str]:
+    sample_root = Path(samples_dir).resolve()
+    db_file = Path(db_path).resolve()
+    if db_file.exists():
+        db_file.unlink()
+
+    _load_master_accounts(str(db_file), fiscal_year)
+    _seed_opening_balances(str(db_file), fiscal_year)
+
+    sample_files = [
+        sample_root / "erpnext" / "sales_invoices.csv",
+        sample_root / "erpnext" / "purchase_invoices.csv",
+        sample_root / "mufg_bank" / "9999999_sample.csv",
+        sample_root / "smbc_bank" / "meisai.csv",
+        sample_root / "aeon_card" / "meisai202502.csv",
+        sample_root / "sumitomo_visa" / "202502.csv",
+        sample_root / "sumitomo_visa" / "202503.csv",
+        sample_root / "sumitomo_visa" / "202504.csv",
+        sample_root / "rakuten_card" / "enavi202502_9999.csv",
+        sample_root / "view_card" / "statement_202502.csv",
+    ]
+    for sample_file in sample_files:
+        _load_csv_candidates(str(db_file), fiscal_year, sample_file)
+
+    _load_fixed_assets_sample(str(db_file), fiscal_year, sample_root / "fixed_assets" / "fixed_assets.csv")
+    _seed_audit_and_duplicates(str(db_file), fiscal_year, sample_root)
+
+    conn = init_db(str(db_file))
+    try:
+        journal_count = int(
+            conn.execute("SELECT COUNT(*) FROM journals WHERE fiscal_year = ?", (fiscal_year,)).fetchone()[0]
+        )
+        fixed_asset_count = int(
+            conn.execute("SELECT COUNT(*) FROM fixed_assets WHERE fiscal_year = ?", (fiscal_year,)).fetchone()[0]
+        )
+        adjusted_count = int(conn.execute("SELECT COUNT(*) FROM journal_audit_log").fetchone()[0])
+    finally:
+        conn.close()
+
+    return {
+        "status": "ok",
+        "db_path": str(db_file),
+        "fiscal_year": fiscal_year,
+        "journal_count": journal_count,
+        "fixed_asset_count": fixed_asset_count,
+        "adjusted_count": adjusted_count,
+    }

--- a/tests/integration/test_demo_data.py
+++ b/tests/integration/test_demo_data.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from tests.helpers.demo_data import build_capture_demo_db
+
+
+def test_build_capture_demo_db_creates_demo_content(tmp_path: Path) -> None:
+    db_path = tmp_path / "capture_demo.db"
+    samples_dir = Path("input_samples").resolve()
+
+    result = build_capture_demo_db(
+        db_path=str(db_path),
+        fiscal_year=2025,
+        samples_dir=str(samples_dir),
+        reference_export_path=str(Path("output/exports/journals_2025.csv").resolve()),
+    )
+
+    assert result["status"] == "ok"
+    assert result["journal_count"] > 10
+    assert result["fixed_asset_count"] >= 1
+    assert result["adjusted_count"] >= 1
+
+    conn = sqlite3.connect(db_path)
+    try:
+        fixed_asset = conn.execute(
+            "SELECT name, acquisition_cost FROM fixed_assets WHERE fiscal_year = 2025 ORDER BY id LIMIT 1"
+        ).fetchone()
+        assert fixed_asset == ("開発用ノートPC", 198000)
+
+        total_sales = conn.execute(
+            "SELECT COALESCE(SUM(amount), 0) FROM journal_lines "
+            "WHERE side = 'credit' AND account_code = '4001'"
+        ).fetchone()[0]
+        assert total_sales == 1518000
+
+        audit_count = conn.execute("SELECT COUNT(*) FROM journal_audit_log").fetchone()[0]
+        assert audit_count >= 1
+
+        imported_sources = conn.execute("SELECT COUNT(*) FROM import_sources").fetchone()[0]
+        assert imported_sources >= 5
+    finally:
+        conn.close()

--- a/tests/integration/test_web_smoke.py
+++ b/tests/integration/test_web_smoke.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from shinkoku.db import get_connection, init_db
+from shinkoku.master_accounts import MASTER_ACCOUNTS
+from shinkoku.models import JournalEntry, JournalLine, OpeningBalanceInput
+from shinkoku.tools.ledger import (
+    ledger_add_journal,
+    ledger_set_opening_balances_batch,
+    ledger_update_journal,
+)
+from shinkoku.web.app import create_app
+
+
+def _load_accounts(conn: sqlite3.Connection) -> None:
+    for account in MASTER_ACCOUNTS:
+        conn.execute(
+            "INSERT OR IGNORE INTO accounts (code, name, category, sub_category, tax_category) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (
+                account["code"],
+                account["name"],
+                account["category"],
+                account["sub_category"],
+                account["tax_category"],
+            ),
+        )
+
+
+def _seed_web_demo_db(db_path: str, source_file: str) -> int:
+    conn = init_db(db_path)
+    _load_accounts(conn)
+    conn.execute("INSERT OR IGNORE INTO fiscal_years (year) VALUES (2025)")
+    conn.execute(
+        "INSERT INTO fixed_assets "
+        "(name, acquisition_date, acquisition_cost, useful_life, method, "
+        "business_use_ratio, accumulated_depreciation, fiscal_year, memo) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            "開発用ノートPC",
+            "2025-02-01",
+            198000,
+            4,
+            "straight_line",
+            100,
+            0,
+            2025,
+            "画面確認用サンプル",
+        ),
+    )
+    conn.execute(
+        "INSERT INTO import_sources (fiscal_year, file_hash, file_name, file_path, row_count) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (2025, "demo-file-hash", Path(source_file).name, source_file, 1),
+    )
+    conn.commit()
+    conn.close()
+
+    ledger_set_opening_balances_batch(
+        db_path=db_path,
+        fiscal_year=2025,
+        balances=[
+            OpeningBalanceInput(account_code="1002", amount=500000),
+            OpeningBalanceInput(account_code="3001", amount=500000),
+        ],
+    )
+
+    sale = JournalEntry(
+        date="2025-01-15",
+        description="ウェブ開発報酬",
+        lines=[
+            JournalLine(side="debit", account_code="1002", amount=100000),
+            JournalLine(side="credit", account_code="4001", amount=100000),
+        ],
+        source="csv_import",
+        source_file=source_file,
+    )
+    sale_added = ledger_add_journal(db_path=db_path, fiscal_year=2025, entry=sale)
+    sale_id = int(sale_added["journal_id"])
+
+    sale_updated = JournalEntry(
+        date="2025-01-15",
+        description="ウェブ開発報酬",
+        counterparty="株式会社青葉工務店",
+        lines=[
+            JournalLine(side="debit", account_code="1002", amount=100000),
+            JournalLine(side="credit", account_code="4001", amount=100000),
+        ],
+        source="csv_import",
+        source_file=source_file,
+    )
+    ledger_update_journal(
+        db_path=db_path,
+        journal_id=sale_id,
+        fiscal_year=2025,
+        entry=sale_updated,
+    )
+
+    internet = JournalEntry(
+        date="2025-01-20",
+        description="インターネット回線",
+        counterparty="NTT東日本",
+        lines=[
+            JournalLine(side="debit", account_code="5140", amount=5000),
+            JournalLine(side="credit", account_code="1002", amount=5000),
+        ],
+        source="manual",
+    )
+    ledger_add_journal(db_path=db_path, fiscal_year=2025, entry=internet)
+
+    duplicate_a = JournalEntry(
+        date="2025-02-10",
+        description="文房具購入A",
+        lines=[
+            JournalLine(side="debit", account_code="5190", amount=3000),
+            JournalLine(side="credit", account_code="1002", amount=3000),
+        ],
+        source="manual",
+    )
+    duplicate_b = JournalEntry(
+        date="2025-02-10",
+        description="文房具購入B",
+        lines=[
+            JournalLine(side="debit", account_code="5270", amount=3000),
+            JournalLine(side="credit", account_code="1001", amount=3000),
+        ],
+        source="manual",
+    )
+    ledger_add_journal(db_path=db_path, fiscal_year=2025, entry=duplicate_a)
+    ledger_add_journal(db_path=db_path, fiscal_year=2025, entry=duplicate_b, force=True)
+
+    return sale_id
+
+
+def test_web_smoke_basic_tour(tmp_path: Path) -> None:
+    db_path = str(tmp_path / "web-smoke.db")
+    source_file = tmp_path / "import_sample.csv"
+    source_file.write_text("日付,摘要,金額\n2025-01-15,ウェブ開発報酬,100000\n", encoding="utf-8")
+    sale_id = _seed_web_demo_db(db_path, str(source_file))
+
+    conn = get_connection(db_path)
+    try:
+        audit_log_id = int(
+            conn.execute(
+                "SELECT id FROM journal_audit_log WHERE journal_id = ? ORDER BY id DESC LIMIT 1",
+                (sale_id,),
+            ).fetchone()[0]
+        )
+    finally:
+        conn.close()
+
+    client = TestClient(create_app(db_path=db_path, fiscal_year=2025))
+
+    response = client.get("/journals")
+    assert response.status_code == 200
+    assert "ウェブ開発報酬" in response.text
+    assert "株式会社青葉工務店" in response.text
+
+    response = client.get("/journals", params={"query": "acc:1002"})
+    assert response.status_code == 200
+    assert "普通預金" in response.text
+
+    response = client.get("/journals", params={"query": 'desc:"ウェブ開発報酬"'})
+    assert response.status_code == 200
+    assert "ウェブ開発報酬" in response.text
+
+    response = client.get("/journals", params={"query": 'cp:"株式会社青葉工務店"'})
+    assert response.status_code == 200
+    assert "株式会社青葉工務店" in response.text
+
+    response = client.get(
+        "/journals",
+        params={"query": "from:2025-01-01 to:2025-02-28 cat:expense"},
+    )
+    assert response.status_code == 200
+    assert "インターネット回線" in response.text
+
+    response = client.get("/journals.csv")
+    assert response.status_code == 200
+    assert "text/csv" in response.headers["content-type"]
+    assert "journal_id,date,description" in response.text
+
+    response = client.get("/trial-balance")
+    assert response.status_code == 200
+    assert "勘定科目サマリ" in response.text
+
+    response = client.get("/gl/1002")
+    assert response.status_code == 200
+    assert "総勘定元帳" in response.text
+    assert "普通預金" in response.text
+
+    response = client.get("/summary/description")
+    assert response.status_code == 200
+    assert "摘要サマリ" in response.text
+
+    response = client.get("/summary/counterparty")
+    assert response.status_code == 200
+    assert "取引先サマリ" in response.text
+
+    response = client.get(
+        "/summary/monthly",
+        params={"date_from": "2025-01-01", "date_to": "2025-12-31", "category": "expense"},
+    )
+    assert response.status_code == 200
+    assert "月次サマリ" in response.text
+
+    response = client.get("/source-links")
+    assert response.status_code == 200
+    assert "入力元サマリ" in response.text
+    assert source_file.name in response.text
+
+    response = client.get("/source-links/detail", params={"path": str(source_file)})
+    assert response.status_code == 200
+    assert "入力元詳細" in response.text
+    assert "ウェブ開発報酬" in response.text
+
+    response = client.get("/pl")
+    assert response.status_code == 200
+    assert "損益計算書" in response.text
+
+    response = client.get("/bs")
+    assert response.status_code == 200
+    assert "貸借対照表" in response.text
+    assert "当期純利益" in response.text
+
+    response = client.get("/duplicates", params={"threshold": 70})
+    assert response.status_code == 200
+    assert "重複候補" in response.text
+    assert "文房具購入A" in response.text
+
+    response = client.get("/fixed-assets")
+    assert response.status_code == 200
+    assert "固定資産台帳" in response.text
+    assert "開発用ノートPC" in response.text
+
+    response = client.get("/audit")
+    assert response.status_code == 200
+    assert "監査ログ" in response.text
+    assert "update" in response.text
+
+    response = client.get("/audit/detail", params={"log_id": audit_log_id})
+    assert response.status_code == 200
+    assert "株式会社青葉工務店" in response.text
+
+    response = client.get("/audit/diff", params={"log_id": audit_log_id})
+    assert response.status_code == 200
+    assert "差分" in response.text or "before" in response.text or "after" in response.text

--- a/tests/tools/capture_web_ui_screenshots.py
+++ b/tests/tools/capture_web_ui_screenshots.py
@@ -1,0 +1,422 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+from urllib.parse import urlencode, urljoin
+
+import yaml
+from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+from playwright.sync_api import sync_playwright
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from tests.helpers.demo_data import build_capture_demo_db
+
+DEFAULT_OUTPUT_DIR = ROOT_DIR / "output" / "web-ui-latest"
+DEFAULT_CONFIG_PATH = ROOT_DIR / "shinkoku.config.yaml"
+DEFAULT_SAMPLES_DIR = ROOT_DIR / "input_samples"
+DEFAULT_REFERENCE_EXPORT = ROOT_DIR / "output" / "exports" / "journals_2025.csv"
+DEFAULT_APP_PORT = 8010
+DEFAULT_DEMO_PORT = 8011
+
+
+def _load_config_defaults(config_path: Path) -> tuple[str | None, int | None]:
+    if not config_path.exists():
+        return None, None
+    data = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    db_path = data.get("db_path")
+    tax_year = data.get("tax_year")
+    resolved_db_path = None
+    if db_path:
+        raw = Path(str(db_path))
+        resolved_db_path = str((config_path.parent / raw).resolve() if not raw.is_absolute() else raw)
+    return resolved_db_path, int(tax_year) if tax_year is not None else None
+
+
+def _is_port_open(host: str, port: int) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(0.5)
+        return sock.connect_ex((host, port)) == 0
+
+
+def _wait_for_server(base_url: str, timeout_sec: float = 15.0) -> None:
+    import urllib.request
+
+    deadline = time.time() + timeout_sec
+    last_error: Exception | None = None
+    while time.time() < deadline:
+        try:
+            with urllib.request.urlopen(f"{base_url}/health", timeout=1.0) as response:
+                if response.status == 200:
+                    return
+        except Exception as exc:  # pragma: no cover - best effort polling
+            last_error = exc
+            time.sleep(0.3)
+    raise RuntimeError(f"Web UI did not become ready: {last_error}")
+
+
+def _start_server(*, db_path: str, fiscal_year: int, host: str, port: int, log_dir: Path) -> subprocess.Popen[str]:
+    log_dir.mkdir(parents=True, exist_ok=True)
+    stdout = (log_dir / "capture-server.out.log").open("w", encoding="utf-8")
+    stderr = (log_dir / "capture-server.err.log").open("w", encoding="utf-8")
+    env = os.environ.copy()
+    env["PYTHONPATH"] = f"{ROOT_DIR / 'src'}{os.pathsep}{env.get('PYTHONPATH', '')}".rstrip(os.pathsep)
+    return subprocess.Popen(
+        [
+            str(ROOT_DIR / ".venv" / "bin" / "python"),
+            "-m",
+            "shinkoku.cli",
+            "web",
+            "--db-path",
+            db_path,
+            "--fiscal-year",
+            str(fiscal_year),
+            "--host",
+            host,
+            "--port",
+            str(port),
+        ],
+        cwd=str(ROOT_DIR),
+        env=env,
+        stdout=stdout,
+        stderr=stderr,
+        text=True,
+    )
+
+
+def _safe_wait(page) -> None:
+    try:
+        page.wait_for_load_state("networkidle", timeout=3_000)
+    except PlaywrightTimeoutError:
+        page.wait_for_timeout(500)
+
+
+def _capture_page(
+    page,
+    *,
+    base_url: str,
+    output_dir: Path,
+    order: int,
+    label: str,
+    path: str,
+) -> dict[str, str]:
+    url = f"{base_url}{path}"
+    page.goto(url, wait_until="domcontentloaded")
+    _safe_wait(page)
+    target = output_dir / f"{order:02d}_{label}.png"
+    page.screenshot(path=str(target), full_page=True)
+    return {"order": f"{order:02d}", "label": label, "url": url, "file": target.name, "kind": "screenshot"}
+
+
+def _download_file(*, base_url: str, output_dir: Path, order: int, label: str, path: str) -> dict[str, str]:
+    import urllib.request
+
+    url = f"{base_url}{path}"
+    target = output_dir / f"{order:02d}_{label}.csv"
+    with urllib.request.urlopen(url, timeout=10) as response:
+        target.write_bytes(response.read())
+    return {"order": f"{order:02d}", "label": label, "url": url, "file": target.name, "kind": "download"}
+
+
+def _first_href(page, selector: str, *, exclude_substrings: list[str] | None = None) -> str | None:
+    exclude_substrings = exclude_substrings or []
+    locator = page.locator(selector)
+    count = locator.count()
+    for idx in range(count):
+        href = locator.nth(idx).get_attribute("href")
+        if not href:
+            continue
+        if any(token in href for token in exclude_substrings):
+            continue
+        return href
+    return None
+
+
+def _build_routes() -> list[tuple[str, str]]:
+    return [
+        ("仕訳一覧", "/journals"),
+        ("入力元を表示", "/journals?show_source=1"),
+        ("勘定科目サマリ", "/trial-balance"),
+        ("摘要サマリ", "/summary/description"),
+        ("取引先サマリ", "/summary/counterparty"),
+        ("月次サマリ", f"/summary/monthly?{urlencode({'date_from': '2025-01-01', 'date_to': '2025-12-31', 'category': 'expense'})}"),
+        ("入力元サマリ", "/source-links"),
+        ("PL", "/pl"),
+        ("BS", "/bs"),
+        ("重複候補", "/duplicates?threshold=70"),
+        ("固定資産", "/fixed-assets"),
+        ("監査ログ", "/audit"),
+    ]
+
+
+def _resolve_base_url(args: argparse.Namespace) -> tuple[int, str]:
+    if args.base_url:
+        return args.port, args.base_url
+    if args.build_demo_db and args.port == DEFAULT_APP_PORT:
+        args.port = DEFAULT_DEMO_PORT
+    return args.port, f"http://{args.host}:{args.port}"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Capture latest Web UI screenshots into one directory.")
+    parser.add_argument("--db-path")
+    parser.add_argument("--fiscal-year", type=int)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", default=DEFAULT_APP_PORT, type=int)
+    parser.add_argument("--base-url")
+    parser.add_argument("--output-dir", default=str(DEFAULT_OUTPUT_DIR))
+    parser.add_argument("--config", default=str(DEFAULT_CONFIG_PATH))
+    parser.add_argument("--browser-path", default="")
+    parser.add_argument("--samples-dir", default=str(DEFAULT_SAMPLES_DIR))
+    parser.add_argument("--reference-export", default=str(DEFAULT_REFERENCE_EXPORT))
+    parser.add_argument("--build-demo-db", action="store_true")
+    args = parser.parse_args()
+
+    config_db_path, config_fiscal_year = _load_config_defaults(Path(args.config))
+    db_path = args.db_path or config_db_path
+    fiscal_year = args.fiscal_year or config_fiscal_year
+    if not db_path or not fiscal_year:
+        raise SystemExit("--db-path and --fiscal-year are required when config defaults are unavailable")
+
+    output_dir = Path(args.output_dir).resolve()
+    if output_dir.exists():
+        shutil.rmtree(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    if args.build_demo_db:
+        db_path = str(output_dir / "capture_demo.db")
+        build_capture_demo_db(
+            db_path=db_path,
+            fiscal_year=fiscal_year,
+            samples_dir=args.samples_dir,
+            reference_export_path=args.reference_export,
+        )
+
+    port, base_url = _resolve_base_url(args)
+    started_server = False
+    server_process: subprocess.Popen[str] | None = None
+
+    try:
+        if args.build_demo_db:
+            if _is_port_open(args.host, port):
+                raise SystemExit(
+                    f"Demo capture port {port} is already in use. "
+                    "Stop the existing server or pass --port with an unused port."
+                )
+            started_server = True
+            server_process = _start_server(
+                db_path=db_path,
+                fiscal_year=fiscal_year,
+                host=args.host,
+                port=port,
+                log_dir=output_dir,
+            )
+            _wait_for_server(base_url)
+        elif not _is_port_open(args.host, port):
+            started_server = True
+            server_process = _start_server(
+                db_path=db_path,
+                fiscal_year=fiscal_year,
+                host=args.host,
+                port=port,
+                log_dir=output_dir,
+            )
+            _wait_for_server(base_url)
+
+        with sync_playwright() as playwright:
+            launch_kwargs: dict[str, object] = {"headless": True}
+            browser_path = args.browser_path or shutil.which("chromium-browser") or shutil.which("chromium")
+            if browser_path:
+                launch_kwargs["executable_path"] = browser_path
+            browser = playwright.chromium.launch(**launch_kwargs)
+            page = browser.new_page(viewport={"width": 1440, "height": 2200}, device_scale_factor=1)
+
+            manifest: list[dict[str, str]] = []
+
+            manifest.append(_capture_page(page, base_url=base_url, output_dir=output_dir, order=1, label="仕訳一覧", path="/journals"))
+            manifest.append(_capture_page(page, base_url=base_url, output_dir=output_dir, order=2, label="入力元を表示", path="/journals?show_source=1"))
+            manifest.append(_download_file(base_url=base_url, output_dir=output_dir, order=3, label="ダウンロード（csv）", path="/journals.csv"))
+            manifest.append(_capture_page(page, base_url=base_url, output_dir=output_dir, order=4, label="勘定科目サマリ", path="/trial-balance"))
+            page.goto(f"{base_url}/trial-balance", wait_until="domcontentloaded")
+            _safe_wait(page)
+            journals_acc_href = _first_href(page, 'tbody a[href^="/journals?query=acc%3A"]')
+            if journals_acc_href:
+                manifest.append(
+                    _capture_page(
+                        page,
+                        base_url=base_url,
+                        output_dir=output_dir,
+                        order=5,
+                        label="仕訳一覧（acc）",
+                        path=journals_acc_href,
+                    )
+                )
+            manifest.append(_capture_page(page, base_url=base_url, output_dir=output_dir, order=6, label="総勘定元帳（普通預金）", path="/gl/1002"))
+
+            manifest.append(_capture_page(page, base_url=base_url, output_dir=output_dir, order=7, label="摘要サマリ", path="/summary/description"))
+            page.goto(f"{base_url}/summary/description", wait_until="domcontentloaded")
+            _safe_wait(page)
+            summary_description_href = _first_href(page, 'tbody a[href^="/journals?query="]')
+            if summary_description_href:
+                manifest.append(
+                    _capture_page(
+                        page,
+                        base_url=base_url,
+                        output_dir=output_dir,
+                        order=8,
+                        label="仕訳一覧（desc）",
+                        path=summary_description_href,
+                    )
+                )
+
+            manifest.append(_capture_page(page, base_url=base_url, output_dir=output_dir, order=9, label="取引先サマリ", path="/summary/counterparty"))
+            page.goto(f"{base_url}/summary/counterparty", wait_until="domcontentloaded")
+            _safe_wait(page)
+            summary_counterparty_href = _first_href(
+                page,
+                'tbody a[href^="/journals?query="]',
+                exclude_substrings=['cp%3A%22%22', 'cp:""'],
+            )
+            if summary_counterparty_href:
+                manifest.append(
+                    _capture_page(
+                        page,
+                        base_url=base_url,
+                        output_dir=output_dir,
+                        order=10,
+                        label="仕訳一覧（cp）",
+                        path=summary_counterparty_href,
+                    )
+                )
+
+            manifest.append(
+                _capture_page(
+                    page,
+                    base_url=base_url,
+                    output_dir=output_dir,
+                    order=11,
+                    label="月次サマリ",
+                    path=f"/summary/monthly?{urlencode({'date_from': '2025-01-01', 'date_to': '2025-12-31', 'category': 'expense'})}",
+                )
+            )
+            page.goto(f"{base_url}/summary/monthly", wait_until="domcontentloaded")
+            _safe_wait(page)
+            summary_monthly_href = _first_href(page, 'tbody td:nth-child(2) a[href*="cat%3A"]')
+            if not summary_monthly_href:
+                summary_monthly_href = _first_href(page, 'tbody a[href*="cat%3A"]')
+            if summary_monthly_href:
+                manifest.append(
+                    _capture_page(
+                        page,
+                        base_url=base_url,
+                        output_dir=output_dir,
+                        order=12,
+                        label="仕訳一覧（from_to_cat）",
+                        path=summary_monthly_href,
+                    )
+                )
+
+            manifest.append(_capture_page(page, base_url=base_url, output_dir=output_dir, order=13, label="入力元サマリ", path="/source-links"))
+            page.goto(f"{base_url}/source-links", wait_until="domcontentloaded")
+            _safe_wait(page)
+            source_detail_href = _first_href(page, 'a[href^="/source-links/detail"]')
+            if source_detail_href:
+                manifest.append(
+                    _capture_page(
+                        page,
+                        base_url=base_url,
+                        output_dir=output_dir,
+                        order=14,
+                        label="入力元詳細",
+                        path=source_detail_href,
+                    )
+                )
+                page.goto(urljoin(base_url, source_detail_href), wait_until="domcontentloaded")
+                _safe_wait(page)
+                source_file_journals_href = _first_href(page, 'a[href^="/journals?query=file%3A"]')
+                if source_file_journals_href:
+                    manifest.append(
+                        _capture_page(
+                            page,
+                            base_url=base_url,
+                            output_dir=output_dir,
+                            order=15,
+                            label="仕訳一覧（file）",
+                            path=source_file_journals_href,
+                        )
+                    )
+
+            manifest.append(_capture_page(page, base_url=base_url, output_dir=output_dir, order=16, label="PL", path="/pl"))
+            manifest.append(_capture_page(page, base_url=base_url, output_dir=output_dir, order=17, label="BS", path="/bs"))
+            manifest.append(_capture_page(page, base_url=base_url, output_dir=output_dir, order=18, label="重複候補", path="/duplicates?threshold=70"))
+            manifest.append(_capture_page(page, base_url=base_url, output_dir=output_dir, order=20, label="固定資産", path="/fixed-assets"))
+            manifest.append(_capture_page(page, base_url=base_url, output_dir=output_dir, order=21, label="監査ログ", path="/audit"))
+
+            page.goto(f"{base_url}/audit", wait_until="domcontentloaded")
+            _safe_wait(page)
+            audit_detail_href = _first_href(page, 'a[href^="/audit/detail"]')
+            if audit_detail_href:
+                manifest.append(
+                    _capture_page(
+                        page,
+                        base_url=base_url,
+                        output_dir=output_dir,
+                        order=22,
+                        label="監査ログ詳細",
+                        path=audit_detail_href,
+                    )
+                )
+
+            page.goto(f"{base_url}/duplicates?threshold=70", wait_until="domcontentloaded")
+            _safe_wait(page)
+            duplicate_journals_href = _first_href(page, 'a[href^="/journals?query=from%3A"]')
+            if duplicate_journals_href:
+                manifest.append(
+                    _capture_page(
+                        page,
+                        base_url=base_url,
+                        output_dir=output_dir,
+                        order=19,
+                        label="仕訳一覧（from_to_mfrom_mto）",
+                        path=duplicate_journals_href,
+                    )
+                )
+
+            browser.close()
+
+        (output_dir / "manifest.json").write_text(
+            json.dumps(
+                {
+                    "base_url": base_url,
+                    "db_path": db_path,
+                    "fiscal_year": fiscal_year,
+                    "captured_at": time.strftime("%Y-%m-%d %H:%M:%S"),
+                    "files": sorted(manifest, key=lambda item: int(item["order"])),
+                },
+                ensure_ascii=False,
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+        print(str(output_dir))
+        return 0
+    finally:
+        if started_server and server_process is not None:
+            server_process.terminate()
+            try:
+                server_process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                server_process.kill()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tools/capture_web_ui_screenshots.py
+++ b/tests/tools/capture_web_ui_screenshots.py
@@ -19,8 +19,6 @@ ROOT_DIR = Path(__file__).resolve().parents[2]
 if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
 
-from tests.helpers.demo_data import build_capture_demo_db
-
 DEFAULT_OUTPUT_DIR = ROOT_DIR / "output" / "web-ui-latest"
 DEFAULT_CONFIG_PATH = ROOT_DIR / "shinkoku.config.yaml"
 DEFAULT_SAMPLES_DIR = ROOT_DIR / "input_samples"
@@ -193,6 +191,8 @@ def main() -> int:
     output_dir.mkdir(parents=True, exist_ok=True)
 
     if args.build_demo_db:
+        from tests.helpers.demo_data import build_capture_demo_db
+
         db_path = str(output_dir / "capture_demo.db")
         build_capture_demo_db(
             db_path=db_path,

--- a/tests/tools/capture_web_ui_screenshots.py
+++ b/tests/tools/capture_web_ui_screenshots.py
@@ -12,8 +12,6 @@ from pathlib import Path
 from urllib.parse import urlencode, urljoin
 
 import yaml
-from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
-from playwright.sync_api import sync_playwright
 
 ROOT_DIR = Path(__file__).resolve().parents[2]
 if str(ROOT_DIR) not in sys.path:
@@ -92,6 +90,8 @@ def _start_server(*, db_path: str, fiscal_year: int, host: str, port: int, log_d
 
 
 def _safe_wait(page) -> None:
+    from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
+
     try:
         page.wait_for_load_state("networkidle", timeout=3_000)
     except PlaywrightTimeoutError:
@@ -204,6 +204,14 @@ def main() -> int:
     port, base_url = _resolve_base_url(args)
     started_server = False
     server_process: subprocess.Popen[str] | None = None
+
+    try:
+        from playwright.sync_api import sync_playwright
+    except ModuleNotFoundError as exc:  # pragma: no cover - environment guard
+        raise SystemExit(
+            "playwright is required to capture Web UI screenshots. "
+            "Install the dev dependencies with `uv sync --all-extras`."
+        ) from exc
 
     try:
         if args.build_demo_db:

--- a/tests/unit/test_capture_web_ui_screenshots.py
+++ b/tests/unit/test_capture_web_ui_screenshots.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from argparse import Namespace
+
+from tests.tools.capture_web_ui_screenshots import (
+    DEFAULT_APP_PORT,
+    DEFAULT_DEMO_PORT,
+    _resolve_base_url,
+)
+
+
+def test_resolve_base_url_keeps_default_port_for_normal_capture() -> None:
+    args = Namespace(
+        base_url=None,
+        build_demo_db=False,
+        host="127.0.0.1",
+        port=DEFAULT_APP_PORT,
+    )
+
+    port, base_url = _resolve_base_url(args)
+
+    assert port == DEFAULT_APP_PORT
+    assert base_url == "http://127.0.0.1:8010"
+
+
+def test_resolve_base_url_uses_demo_port_for_demo_capture() -> None:
+    args = Namespace(
+        base_url=None,
+        build_demo_db=True,
+        host="127.0.0.1",
+        port=DEFAULT_APP_PORT,
+    )
+
+    port, base_url = _resolve_base_url(args)
+
+    assert port == DEFAULT_DEMO_PORT
+    assert base_url == "http://127.0.0.1:8011"
+
+
+def test_resolve_base_url_keeps_explicit_port_for_demo_capture() -> None:
+    args = Namespace(
+        base_url=None,
+        build_demo_db=True,
+        host="127.0.0.1",
+        port=8123,
+    )
+
+    port, base_url = _resolve_base_url(args)
+
+    assert port == 8123
+    assert base_url == "http://127.0.0.1:8123"

--- a/tests/unit/test_duplicate_detection.py
+++ b/tests/unit/test_duplicate_detection.py
@@ -129,6 +129,22 @@ class TestSourceFileCheck:
 
 
 class TestFindDuplicatePairs:
+    def test_find_duplicate_pairs_same_accounts_scores_90(self, in_memory_db_with_accounts):
+        """Same date/amount/accounts should be promoted to score 90."""
+        db = in_memory_db_with_accounts
+        db.execute("INSERT INTO fiscal_years (year) VALUES (2025)")
+        db.commit()
+
+        id1 = _insert_journal(db, _make_entry(description="first"), include_hash=False)
+        id2 = _insert_journal(db, _make_entry(description="second"), include_hash=False)
+
+        result = find_duplicate_pairs(db, 2025)
+
+        pairs = {(p.journal_id_a, p.journal_id_b): p for p in result.pairs}
+        pair = pairs[(min(id1, id2), max(id1, id2))]
+        assert pair.score == 90
+        assert "同一勘定科目" in pair.reason
+
     def test_find_duplicate_pairs_legacy_exact(self, in_memory_db_with_accounts):
         """Legacy entries (NULL hash) with identical content detected via date+amount+accounts."""
         db = in_memory_db_with_accounts

--- a/tests/unit/test_opening_balance.py
+++ b/tests/unit/test_opening_balance.py
@@ -243,3 +243,50 @@ def test_ledger_bs_no_opening_balances(tmp_path):
     assert result["opening_total_assets"] == 0
     assert result["opening_total_liabilities"] == 0
     assert result["opening_total_equity"] == 0
+
+
+def test_ledger_bs_reflects_current_profit_in_equity(tmp_path):
+    """当期純利益が純資産合計に反映されること。"""
+    from shinkoku.db import init_db
+    from shinkoku.master_accounts import MASTER_ACCOUNTS
+    from shinkoku.models import JournalEntry, JournalLine
+    from shinkoku.tools.ledger import ledger_add_journal
+
+    db_path = str(tmp_path / "bs_profit.db")
+    conn = init_db(db_path)
+    for a in MASTER_ACCOUNTS:
+        conn.execute(
+            "INSERT OR IGNORE INTO accounts (code, name, category, sub_category, tax_category) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (a["code"], a["name"], a["category"], a["sub_category"], a["tax_category"]),
+        )
+    conn.execute("INSERT INTO fiscal_years (year) VALUES (2025)")
+    conn.commit()
+    conn.close()
+
+    sale = JournalEntry(
+        date="2025-01-10",
+        description="売上",
+        lines=[
+            JournalLine(side="debit", account_code="1002", amount=10000),
+            JournalLine(side="credit", account_code="4001", amount=10000),
+        ],
+    )
+    expense = JournalEntry(
+        date="2025-01-11",
+        description="消耗品",
+        lines=[
+            JournalLine(side="debit", account_code="5270", amount=3000),
+            JournalLine(side="credit", account_code="1002", amount=3000),
+        ],
+    )
+    assert ledger_add_journal(db_path=db_path, fiscal_year=2025, entry=sale)["status"] == "ok"
+    assert ledger_add_journal(db_path=db_path, fiscal_year=2025, entry=expense)["status"] == "ok"
+
+    result = ledger_bs(db_path=db_path, fiscal_year=2025)
+
+    assert result["status"] == "ok"
+    assert result["net_income"] == 7000
+    assert result["total_assets"] == 7000
+    assert result["total_liabilities"] == 0
+    assert result["total_equity"] == 7000

--- a/tests/unit/test_web_app.py
+++ b/tests/unit/test_web_app.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from shinkoku.web.app import (
+    _filter_journals_by_query,
+    _parse_journal_query,
+    _set_query_sort,
+    _source_file_aliases,
+)
+
+
+def test_source_file_aliases_adds_wsl_alias_for_windows_path(tmp_path: Path) -> None:
+    base_dir = tmp_path
+
+    aliases = _source_file_aliases(
+        r"C:\Users\taker\Downloads\journals (6).csv",
+        base_dir=base_dir,
+    )
+
+    assert r"C:\Users\taker\Downloads\journals (6).csv" in aliases
+    assert "/mnt/c/Users/taker/Downloads/journals (6).csv" in aliases
+
+
+def test_source_file_aliases_adds_windows_alias_for_wsl_path(tmp_path: Path) -> None:
+    base_dir = tmp_path
+
+    aliases = _source_file_aliases(
+        "/mnt/d/project/shinkoku/shinkoku/input_samples/aeon_card/meisai202502.csv",
+        base_dir=base_dir,
+    )
+
+    assert "/mnt/d/project/shinkoku/shinkoku/input_samples/aeon_card/meisai202502.csv" in aliases
+    assert r"D:\project\shinkoku\shinkoku\input_samples\aeon_card\meisai202502.csv" in aliases
+
+
+def test_parse_journal_query_parses_structured_terms() -> None:
+    parsed = _parse_journal_query(
+        'acc:1112 cat:asset desc:"ノート PC" cp:青葉 src:csv_import '
+        'file:/mnt/c/tmp/a.csv from:2025-01-01 to:2025-01-31 mfrom:1000 mto:5000 '
+        'sort:date desc freeword -除外'
+    )
+
+    assert parsed["account_code"] == "1112"
+    assert parsed["category"] == "asset"
+    assert parsed["description_terms"] == ["ノート PC"]
+    assert parsed["counterparty_terms"] == ["青葉"]
+    assert parsed["source"] == "csv_import"
+    assert parsed["source_file"] == "/mnt/c/tmp/a.csv"
+    assert parsed["date_from"] == "2025-01-01"
+    assert parsed["date_to"] == "2025-01-31"
+    assert parsed["amount_min"] == "1000"
+    assert parsed["amount_max"] == "5000"
+    assert parsed["sort"] == "date"
+    assert parsed["dir"] == "desc"
+    assert parsed["free_terms"] == ["freeword"]
+    assert parsed["exclude_terms"] == ["除外"]
+    assert parsed["q"] == "freeword"
+
+
+def test_filter_journals_by_query_matches_and_excludes() -> None:
+    account_names = {"1112": "普通預金", "5270": "消耗品費"}
+    journals = [
+        {
+            "id": 1,
+            "date": "2025-01-04",
+            "description": "文具ステーション デザインノート",
+            "counterparty": "株式会社青葉工務店",
+            "source": "csv_import",
+            "source_file": "/mnt/c/tmp/a.csv",
+            "lines": [
+                {"side": "debit", "account_code": "5270", "amount": 2480},
+                {"side": "credit", "account_code": "1112", "amount": 2480},
+            ],
+        },
+        {
+            "id": 2,
+            "date": "2025-01-05",
+            "description": "除外したい旅費",
+            "counterparty": "別取引先",
+            "source": "manual",
+            "source_file": "",
+            "lines": [
+                {"side": "debit", "account_code": "5270", "amount": 1200},
+                {"side": "credit", "account_code": "1112", "amount": 1200},
+            ],
+        },
+    ]
+
+    filtered = _filter_journals_by_query(
+        journals,
+        free_terms=["デザインノート", "普通預金"],
+        exclude_terms=["除外"],
+        description_terms=["文具ステーション"],
+        counterparty_terms=["青葉工務店"],
+        account_names=account_names,
+    )
+
+    assert [journal["id"] for journal in filtered] == [1]
+
+
+def test_set_query_sort_replaces_existing_sort_terms() -> None:
+    result = _set_query_sort('desc:"ノート PC" sort:amount asc', "date", "desc")
+
+    assert result == '"desc:ノート PC" sort:date desc'

--- a/uv.lock
+++ b/uv.lock
@@ -34,6 +34,15 @@ wheels = [
 ]
 
 [[package]]
+name = "certifi"
+version = "2026.2.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+]
+
+[[package]]
 name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -522,6 +531,34 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]
@@ -1363,28 +1400,30 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "fpdf2" },
+    { name = "httpx" },
+    { name = "lxml" },
     { name = "mypy" },
+    { name = "playwright" },
+    { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "fpdf2" },
-    { name = "lxml" },
-    { name = "playwright" },
-    { name = "pre-commit" },
     { name = "types-pyyaml" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "fastapi", specifier = ">=0.115" },
+    { name = "fpdf2", marker = "extra == 'dev'", specifier = ">=2.7" },
+    { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27" },
     { name = "jinja2", specifier = ">=3.1" },
+    { name = "lxml", marker = "extra == 'dev'", specifier = ">=6.0.2" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10" },
     { name = "pdfplumber", specifier = ">=0.10" },
+    { name = "playwright", marker = "extra == 'dev'", specifier = ">=1.58.0" },
+    { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
@@ -1392,18 +1431,10 @@ requires-dist = [
     { name = "python-multipart", specifier = ">=0.0.20" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },
+    { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.12.20250915" },
     { name = "uvicorn", specifier = ">=0.30" },
 ]
 provides-extras = ["dev"]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "fpdf2", specifier = ">=2.7" },
-    { name = "lxml", specifier = ">=6.0.2" },
-    { name = "playwright", specifier = ">=1.58.0" },
-    { name = "pre-commit", specifier = ">=4.0.0" },
-    { name = "types-pyyaml", specifier = ">=6.0.12.20250915" },
-]
 
 [[package]]
 name = "starlette"


### PR DESCRIPTION
## 概要

Web UI を実際に見ながら確認できるように、デモデータ生成、スモークテスト、スクリーンショット取得用のテストケースを追加しました。

あわせて、これらのテストが WSL 側で収集・実行しやすいように、`httpx` や `playwright` を含むテスト依存関係も整理しています。

## 追加内容

### テストケース
- `tests/helpers/demo_data.py`
  - Web UI 用のデモ DB を組み立てるヘルパーを追加
- `tests/integration/test_demo_data.py`
  - デモデータ生成の確認テストを追加
- `tests/integration/test_web_smoke.py`
  - 主要な Web ルートが 200 を返す smoke テストを追加
- `tests/tools/capture_web_ui_screenshots.py`
  - Web UI を巡回して画面キャプチャを取るデモ/スモーク用ツールを追加
- `tests/unit/test_capture_web_ui_screenshots.py`
  - キャプチャ補助のユーティリティを unit test で確認するケースを追加
- `tests/unit/test_web_app.py`
  - Web 画面の補助ロジック確認を追加
- `tests/unit/test_duplicate_detection.py`
  - 重複候補判定の確認を追加
- `tests/unit/test_opening_balance.py`
  - 期首残高まわりの確認を追加

### 依存関係
- `httpx` を追加
- `playwright` を追加
- デモ/スモーク系のテストが `uv sync --all-extras` で揃うように調整
- `uv.lock` を更新

### 実装上の調整
- `capture_web_ui_screenshots.py` の Playwright import を遅延化し、unit test 収集時に browser deps がなくても落ちないように修正
- Web UI smoke が安定して回るよう、依存収集まわりを整理

## 確認

WSL 側で以下を確認済みです。

```bash
uv sync --all-extras
uv run pytest tests/unit/test_capture_web_ui_screenshots.py tests/integration/test_web_smoke.py -q
